### PR TITLE
feat: Dockerfile for running the mcp server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+WORKDIR /app
+
+ENV PYTHONPATH=/app
+
+ADD . /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends procps
+
+RUN uv sync
+
+RUN chmod +x ./start.sh
+
+ENTRYPOINT ["uv", "run", "./start.sh", "--host", "0.0.0.0", "--tail"]

--- a/start.sh
+++ b/start.sh
@@ -98,6 +98,7 @@ parse_args() {
     MODE="http"
     HOST="$DEFAULT_HOST"
     PORT="$DEFAULT_PORT"
+    TAIL="false"
     
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -115,6 +116,10 @@ parse_args() {
                 ;;
             --stdio)
                 MODE="stdio"
+                shift
+                ;;
+            --tail)
+                TAIL="true"
                 shift
                 ;;
             -h|--help)
@@ -287,7 +292,16 @@ main() {
     fi
     
     start_server
-    exit $?
+    exit_status=$?
+
+    if [[ $exit_status == 0 && $TAIL == "true" ]]; then
+      tail -f mcp_server.log &
+      tail_pid=$!
+      trap 'kill $tail_pid; exit' INT
+      wait $tail_pid
+    fi
+
+    exit $exit_status
 }
 
 # Run main function


### PR DESCRIPTION
Fixes #6 

This adds a Dockerfile for starting the MCP server in a container and updates `start.sh` with a new `--tail` flag.

Previously `start.sh` would exit after starting the MCP server, but this causing the container to immediately close. In order to support the docker container to host the server I added the `--tail` flag to `start.sh` which when set will tail `mcp_server.log` rather than exiting. 

If `./start.sh --tail` is used outside of the container it will continue running until it receives a SIGINT (Ctrl+C) at which point it will stop the server (not just the tail).

Follow up items:
- Decide if we want to also create a Dockerfile for the CLI (I don't see a use case here personally) @maximilien ?
- Update the release CI to build and publish the docker image