### PR TITLE
chore: add docker release ci

### DIFF
--- a/.github/workflows/docker_release.yaml
+++ b/.github/workflows/docker_release.yaml
@@ -1,0 +1,67 @@
+name: Maestro Knowledge Build and Upload Images
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-upload:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Set ENV VARS
+        id: version
+        run: |
+          VERSION=$(grep -E '^(version|tool\.poetry\.version) *= *"[^"]+"' "pyproject.toml" | \
+            head -n 1 | \
+            sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Build and Push Docker Image to ghcr.io
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/maestro-knowledge:${{ steps.version.outputs.version }}-${{ matrix.arch }}
+  upload-manifest:
+    needs: build-upload
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: get docker-compatible GITHUB_ORG
+        run: |
+          echo "GITHUB_ORG=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+      - name: Push multi-arch image to ghcr.io
+        run: |
+          docker manifest create ghcr.io/$GITHUB_ORG/maestro-knowledge:${{ needs.build-upload.outputs.version }} \
+            --amend ghcr.io/$GITHUB_ORG/maestro-knowledge:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro-knowledge:${{ needs.build-upload.outputs.version }}-arm64 &&
+          docker manifest create ghcr.io/$GITHUB_ORG/maestro-knowledge:latest \
+            --amend ghcr.io/$GITHUB_ORG/maestro-knowledge:${{ needs.build-upload.outputs.version }}-x86_64 \
+            --amend ghcr.io/$GITHUB_ORG/maestro-knowledge:${{ needs.build-upload.outputs.version }}-arm64 &&
+          docker manifest push ghcr.io/$GITHUB_ORG/maestro-knowledge:${{ needs.build-upload.outputs.version }}
+          docker manifest push ghcr.io/$GITHUB_ORG/maestro-knowledge:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestro-knowledge"
-version = "0.1.0"
+version = "0.6.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Follow up to #19 

This add a GitHub action CI that will build and push a docker image `maestro-knowledge` to `ghcr.io` when a `v*` tag is cut (which occurs when a release is cut).

I also incremented the version in `pyproject.toml` to the next expected version, it was still set to 0.1.0 and had not been incremented as previous releases were cut. This version is the one used for the image tag and will need to be incremented manually for future releases until we add a releaser CI like in maestro