### PR TITLE
feature: custom embedding support for milvus

### DIFF
--- a/src/maestro_mcp/README.md
+++ b/src/maestro_mcp/README.md
@@ -98,6 +98,8 @@ The MCP server supports flexible embedding strategies for both vector databases:
 - `text-embedding-ada-002`: OpenAI's Ada-002 embedding model
 - `text-embedding-3-small`: OpenAI's text-embedding-3-small model
 - `text-embedding-3-large`: OpenAI's text-embedding-3-large model
+- `custom_local`: Uses a custom, local embedding endpoint. **All three** `CUSTOM_EMBEDDING_URL`, `CUSTOM_EMBEDDING_MODEL`, and `CUSTOM_EMBEDDING_VECTORSIZE` environment variables are **required** for this embedding type. `CUSTOM_EMBEDDING_API_KEY` is optional.
+
 
 ## Multi-Database Support
 
@@ -350,6 +352,10 @@ The server respects the following environment variables:
 
 - `VECTOR_DB_TYPE`: Default vector database type (defaults to "weaviate")
 - `OPENAI_API_KEY`: Required for OpenAI embedding models
+- `CUSTOM_EMBEDDING_URL`: The URL for the custom embedding endpoint (required for `custom_local` embedding for Milvus).
+- `CUSTOM_EMBEDDING_API_KEY`: The API key for the custom embedding endpoint (optional, but recommended for authentication).
+- `CUSTOM_EMBEDDING_MODEL`: The model name for the custom embedding endpoint (required for `custom_local` embedding for Milvus).
+- `CUSTOM_EMBEDDING_VECTORSIZE`: The vector dimension for the `custom_local` embedding model (required when using `custom_local`).
 - Database-specific environment variables for Weaviate and Milvus connections
 
 ## Error Handling

--- a/start.sh
+++ b/start.sh
@@ -203,6 +203,15 @@ start_http_server() {
         print_status "Loading environment variables from .env file..."
         export $(grep -v '^#' "$SCRIPT_DIR/.env" | xargs)
     fi
+
+    if [ -n "$CUSTOM_EMBEDDING_URL" ]; then
+        print_info "🧬 Custom Embedding Endpoint is configured:"
+        print_info "   - URL:    $CUSTOM_EMBEDDING_URL"
+        # Use a default for the model if the variable isn't set
+        print_info "   - Model:  ${CUSTOM_EMBEDDING_MODEL:-nomic-embed-text}"
+    else
+        print_info "🧬 Using default OpenAI embedding configuration."
+    fi
     
     # Start the HTTP server in background
     python -c "

--- a/tests/test_vector_db_factory.py
+++ b/tests/test_vector_db_factory.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache 2.0
 # Copyright (c) 2025 IBM
 
+import os
 import warnings
+from unittest.mock import patch, MagicMock
+
+import pytest
 
 # Suppress Pydantic deprecation warnings from dependencies
 warnings.filterwarnings(
@@ -16,19 +20,17 @@ warnings.filterwarnings(
     message=".*Support for class-based `config`.*",
 )
 
-import sys
-import os
-import pytest
-from unittest.mock import patch, MagicMock
+# Suppress Milvus connection warnings during tests
+warnings.filterwarnings(
+    "ignore", category=UserWarning, message=".*Failed to connect to Milvus.*"
+)
 
-# Add the project root to the Python path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
+# Import from the new modular structure
 from src.db.vector_db_factory import create_vector_database
 
 
 class TestCreateVectorDatabase:
-    """Test cases for the create_vector_database factory function."""
+    """Tests for the vector database factory function."""
 
     def test_create_weaviate_database(self):
         """Test creating a Weaviate vector database."""
@@ -37,9 +39,7 @@ class TestCreateVectorDatabase:
         ) as mock_weaviate_db:
             mock_instance = MagicMock()
             mock_weaviate_db.return_value = mock_instance
-
             db = create_vector_database("weaviate", "TestCollection")
-
             mock_weaviate_db.assert_called_once_with("TestCollection")
             assert db == mock_instance
 
@@ -53,37 +53,41 @@ class TestCreateVectorDatabase:
             assert db == mock_instance
 
     def test_create_unsupported_database(self):
-        """Test creating an unsupported database type."""
+        """Test creating an unsupported vector database."""
         with pytest.raises(
-            ValueError, match="Unsupported vector database type: invalid"
+            ValueError, match="Unsupported vector database type: foobar"
         ):
-            create_vector_database("invalid")
+            create_vector_database("foobar", "TestCollection")
 
     def test_create_database_case_insensitive(self):
-        """Test that database type is case insensitive."""
+        """Test that database type is case-insensitive."""
         with patch(
             "src.db.vector_db_factory.WeaviateVectorDatabase"
         ) as mock_weaviate_db:
-            mock_instance = MagicMock()
-            mock_weaviate_db.return_value = mock_instance
-
-            db = create_vector_database("WEAVIATE", "TestCollection")
-
+            create_vector_database("WeAvIaTe", "TestCollection")
             mock_weaviate_db.assert_called_once_with("TestCollection")
-            assert db == mock_instance
 
     def test_create_database_with_environment_default(self):
-        """Test creating a database with environment variable default."""
-        with (
-            patch(
+        """Test creating a database using the environment variable default."""
+        with patch.dict(os.environ, {"VECTOR_DB_TYPE": "milvus"}):
+            with patch(
+                "src.db.vector_db_factory.MilvusVectorDatabase"
+            ) as mock_milvus_db:
+                mock_instance = MagicMock()
+                mock_milvus_db.return_value = mock_instance
+                db = create_vector_database(collection_name="TestCollection")
+                mock_milvus_db.assert_called_once_with("TestCollection")
+                assert db == mock_instance
+
+    def test_create_database_with_no_type_and_no_env_var(self):
+        """Test creating a database with no type and no env var, defaulting to weaviate."""
+        # Ensure VECTOR_DB_TYPE is not set for this test
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
                 "src.db.vector_db_factory.WeaviateVectorDatabase"
-            ) as mock_weaviate_db,
-            patch.dict("os.environ", {"VECTOR_DB_TYPE": "weaviate"}),
-        ):
-            mock_instance = MagicMock()
-            mock_weaviate_db.return_value = mock_instance
-
-            db = create_vector_database(collection_name="TestCollection")
-
-            mock_weaviate_db.assert_called_once_with("TestCollection")
-            assert db == mock_instance
+            ) as mock_weaviate_db:
+                mock_instance = MagicMock()
+                mock_weaviate_db.return_value = mock_instance
+                db = create_vector_database(collection_name="TestCollection")
+                mock_weaviate_db.assert_called_once_with("TestCollection")
+                assert db == mock_instance


### PR DESCRIPTION
Adds support for configurable embeddings

- milvus only
- client will specify **custom_local** as the model to use
- Model parameters are defined by
  ```
  CUSTOM_EMBEDDING_URL=http://localhost:11434/v1
  CUSTOM_EMBEDDING_MODEL=nomic-embed-text
  CUSTOM_EMBEDDING_API_KEY=dummy
  CUSTOM_EMBEDDING_VECTORSIZE=768
  ```
- tests & docs updated
  
This replaces #10 as a simplification. All custom embedding configuration is server side. A client only choose the custom option. There is no API support for specifying embedding vector size.

Alternative considered - JSON file to define embedding configurations & map to a symbolic name. Kept simple for now, but potential future option.
  

Fixes #8
Fixes #9