### PR TITLE
chore: add post release ci to update version

### DIFF
--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -1,0 +1,35 @@
+name: Post Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  followup-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: run bump_version.py
+        run: |
+          python tools/bump_version.py
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: follow-up after release ${{ github.ref_name }}"
+          branch: followup-${{ github.ref_name }}-${{ github.run_id }}
+          base: main
+          title: "chore: follow-up after release ${{ github.ref_name }}"
+          body: |
+            This PR was automatically created after tagging `${{ github.ref_name }}` to:
+            - Bump `pyproject.toml` to next development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestro-knowledge"
-version = "0.6.0"
+version = "0.7.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import re
+from pathlib import Path
+
+
+def parse_version(tag: str) -> tuple[int, ...]:
+    version_str = tag.lstrip("v")
+    return tuple(map(int, version_str.strip().split(".")))
+
+
+def main():
+    github_tag = os.environ.get("GITHUB_REF_NAME")
+    if not github_tag:
+        print("::error::GITHUB_REF_NAME not set.")
+        exit(1)
+    if not re.fullmatch(r"v\d+\.\d+\.\d+", github_tag):
+        print(
+            f"::error::Invalid GITHUB_REF_NAME '{github_tag}'. Expected format: vX.Y.Z"
+        )
+        exit(1)
+
+    major, minor, patch = parse_version(github_tag)
+    next_version_str = f"{major}.{minor + 1}.0"
+
+    print(f"Bumping pyproject.toml to {next_version_str}")
+
+    repo_root = Path(__file__).resolve().parent.parent
+    pyproject_path = repo_root / "pyproject.toml"
+
+    pyproject_content = pyproject_path.read_text()
+    updated_pyproject = re.sub(
+        r'version\s*=\s*"\d+\.\d+\.\d+"',
+        f'version = "{next_version_str}"',
+        pyproject_content,
+    )
+    pyproject_path.write_text(updated_pyproject)
+    print(f"✔️ Bumped pyproject.toml version to {next_version_str}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #27

This adds a GitHub action that will open a PR after a release that increments the version in pyproject.toml

The CI and script are reused and simplified from maestro