### PR TITLE
feat: add search endpoint for direct doc retrieval

### DIFF
--- a/cli/src/main.go
+++ b/cli/src/main.go
@@ -80,6 +80,12 @@ func addContextualHelp() {
 			ShowContextualHelp("query", "")
 		}
 	}
+
+	searchCmd.PostRun = func(cmd *cobra.Command, args []string) {
+		if !silent {
+			ShowContextualHelp("search", "")
+		}
+	}
 }
 
 func main() {
@@ -115,6 +121,7 @@ A command-line interface for working with Maestro Knowledge configurations.`,
 	rootCmd.AddCommand(documentCmd)
 	rootCmd.AddCommand(embeddingCmd)
 	rootCmd.AddCommand(queryCmd)
+	rootCmd.AddCommand(searchCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(statusCmd)
 

--- a/cli/src/mcp_client.go
+++ b/cli/src/mcp_client.go
@@ -695,16 +695,16 @@ func (c *MCPClient) Search(dbName, query string, limit int, collectionName strin
 		return "", fmt.Errorf("no response from MCP server")
 	}
 
-	resultStr, ok := response.Result.(string)
-	if !ok {
-        prettyJSON, err := json.MarshalIndent(response.Result, "", "  ")
-        if err != nil {
-            return "", fmt.Errorf("unexpected response type from MCP server")
-        }
-		return string(prettyJSON), nil
+	prettyJSON, err := json.MarshalIndent(response.Result, "", "  ")
+	if err != nil {
+		resultStr, ok := response.Result.(string)
+		if !ok {
+			return resultStr, nil
+		}
+		return "", fmt.Errorf("unexpected response type from MCP server")
 	}
 
-	return resultStr, nil
+	return string(prettyJSON), nil
 }
 
 // Close closes the MCP client

--- a/cli/src/search.go
+++ b/cli/src/search.go
@@ -7,17 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	docLimit int
-)
 
-var queryCmd = &cobra.Command{
-	Use:   "query",
-	Short: "Query documents using natural language",
-	Long: `Query documents in a vector database using natural language.
-	
+
+var searchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Search documents using natural language",
+	Long: `Search documents in a vector database using natural language.
+
 This command allows you to ask questions about documents stored in a vector database.
-The query agent will search through the documents and provide relevant answers.`,
+The query agent will search through the documents and return relevant documents.`,
 	Example: `  maestro-k query "What is the main topic of the documents?" --vdb=my-vdb
   maestro-k query "Find information about API endpoints" --vdb=my-vdb --doc-limit 10`,
 	Args: cobra.ExactArgs(1),
@@ -28,7 +26,7 @@ The query agent will search through the documents and provide relevant answers.`
 
 		// Validate inputs
 		if strings.TrimSpace(query) == "" {
-			return fmt.Errorf("query cannot be empty")
+			return fmt.Errorf("search cannot be empty")
 		}
 
 		// Use interactive selection if vdb name is not provided
@@ -45,15 +43,15 @@ The query agent will search through the documents and provide relevant answers.`
 			collectionName = "Test_collection_lowercase" // Default collection
 		}
 
-		return queryVectorDatabase(vdbName, query, collectionName)
+		return searchVectorDatabase(vdbName, query, collectionName)
 	},
 }
 
-func queryVectorDatabase(dbName, query, collectionName string) error {
+func searchVectorDatabase(dbName, query, collectionName string) error {
 	// Initialize progress indicator
 	var progress *ProgressIndicator
 	if ShouldShowProgress() {
-		progress = NewProgressIndicator("Processing query...")
+		progress = NewProgressIndicator("Processing search...")
 		progress.Start()
 	}
 
@@ -65,7 +63,7 @@ func queryVectorDatabase(dbName, query, collectionName string) error {
 		if progress != nil {
 			progress.Stop("Dry run completed")
 		}
-		fmt.Println("[DRY RUN] Would query vector database")
+		fmt.Println("[DRY RUN] Would search vector database")
 		return nil
 	}
 
@@ -97,32 +95,29 @@ func queryVectorDatabase(dbName, query, collectionName string) error {
 	defer client.Close()
 
 	if progress != nil {
-		progress.Update("Executing query...")
+		progress.Update("Executing search...")
 	}
 
-	// Call the query method
-	result, err := client.Query(dbName, query, docLimit, collectionName)
+	// Call the search method
+	result, err := client.Search(dbName, query, docLimit, collectionName)
 	if err != nil {
 		if progress != nil {
-			progress.StopWithError("Query failed")
+			progress.StopWithError("Search failed")
 		}
-		return fmt.Errorf("failed to query vector database: %w", err)
+		return fmt.Errorf("failed to search vector database: %w", err)
 	}
 
 	if progress != nil {
-		progress.Stop("Query completed successfully")
+		progress.Stop("Search completed successfully")
 	}
 
-	if !silent {
-		fmt.Println("OK")
-	}
 	fmt.Println(result)
 	return nil
 }
 
 func init() {
-	// Add flags to query command
-	queryCmd.Flags().String("vdb", "", "Vector database name")
-	queryCmd.Flags().String("collection", "", "Collection name to search in")
-	queryCmd.Flags().IntVarP(&docLimit, "doc-limit", "d", 5, "Maximum number of documents to consider")
+	// Add flags to search command
+	searchCmd.Flags().String("vdb", "", "Vector database name")
+	searchCmd.Flags().String("collection", "", "Collection name to search in")
+	searchCmd.Flags().IntVarP(&docLimit, "doc-limit", "d", 5, "Maximum number of documents to consider")
 }

--- a/cli/src/search.go
+++ b/cli/src/search.go
@@ -7,8 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 var searchCmd = &cobra.Command{
 	Use:   "search",
 	Short: "Search documents using natural language",
@@ -16,8 +14,8 @@ var searchCmd = &cobra.Command{
 
 This command allows you to ask questions about documents stored in a vector database.
 The query agent will search through the documents and return relevant documents.`,
-	Example: `  maestro-k query "What is the main topic of the documents?" --vdb=my-vdb
-  maestro-k query "Find information about API endpoints" --vdb=my-vdb --doc-limit 10`,
+	Example: `  maestro-k search "What is the main topic of the documents?" --vdb=my-vdb
+  maestro-k search "Find information about API endpoints" --vdb=my-vdb --doc-limit 10`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		query := args[0]
@@ -56,7 +54,7 @@ func searchVectorDatabase(dbName, query, collectionName string) error {
 	}
 
 	if verbose {
-		fmt.Println("Querying vector database...")
+		fmt.Println("Searching vector database...")
 	}
 
 	if dryRun {

--- a/cli/tests/search_test.go
+++ b/cli/tests/search_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestSearchHelp tests the search command help
+func TestSearchHelp(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "search", "--help")
+	output, err := cmd.Output()
+
+	if err != nil {
+		t.Fatalf("Failed to run query help command: %v", err)
+	}
+
+	helpOutput := string(output)
+
+	// Check for expected search help content
+	expectedContent := []string{
+		"search",
+		"Search documents in a vector database using natural language",
+		"doc-limit",
+		"Maximum number of documents to consider",
+		"Examples:",
+	}
+
+	for _, expected := range expectedContent {
+		if !contains(helpOutput, expected) {
+			t.Errorf("Search help output should contain '%s'", expected)
+		}
+	}
+}
+
+// TestSearchNoArgs tests the search command with no arguments
+func TestSearchNoArgs(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "search")
+	output, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Error("Search command should fail with no arguments")
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "Error:") {
+		t.Error("Search command should show error message with no arguments")
+	}
+}
+
+// TestSearchEmptyDatabaseName tests the search command with missing vdb flag
+func TestSearchEmptyDatabaseName(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "search", "test query")
+	output, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Error("Search command should fail with missing --vdb flag")
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "Error:") {
+		t.Error("Search command should show error message with missing --vdb flag")
+	}
+}
+
+// TestSearchEmptySearch tests the search command with empty query
+func TestSearchEmptySearch(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "search", "", "--vdb=test-db")
+	output, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Error("Search command should fail with empty query")
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "Error:") {
+		t.Error("Search command should show error message with empty query")
+	}
+}
+
+// TestSearchWithDryRunFlag tests the search command with dry-run flag
+func TestSearchWithDryRunFlag(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "search", "test query", "--vdb=test-db", "--dry-run")
+	output, err := cmd.Output()
+
+	if err != nil {
+		t.Fatalf("Search command with dry-run should not fail: %v", err)
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "[DRY RUN]") {
+		t.Error("Search command with dry-run should show dry run message")
+	}
+}
+
+// TestSearchWithSpecialCharacters tests the search command with special characters
+func TestSearchWithSpecialCharacters(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "search", "What's the deal with API endpoints? (v2.0)", "--vdb=test-db", "--dry-run")
+	output, err := cmd.Output()
+
+	if err != nil {
+		t.Fatalf("Search command with special characters should not fail: %v", err)
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "[DRY RUN]") {
+		t.Error("Search command with special characters should show dry run message")
+	}
+}
+
+// TestSearchWithLongSearch tests the search command with a long query
+func TestSearchWithLongSearch(t *testing.T) {
+	longSearch := "This is a very long query that contains many words and should test the ability of the command to handle long input strings without any issues or problems"
+	cmd := exec.Command("../maestro-k", "search", longSearch, "--vdb=test-db", "--dry-run")
+	output, err := cmd.Output()
+
+	if err != nil {
+		t.Fatalf("Search command with long query should not fail: %v", err)
+	}
+
+	outputStr := string(output)
+	if !contains(outputStr, "[DRY RUN]") {
+		t.Error("Search command with long query should show dry run message")
+	}
+}
+
+// TestSearchInvalidDocLimit tests the search command with invalid doc-limit values
+func TestSearchInvalidDocLimit(t *testing.T) {
+	testCases := []string{"abc", "1.5"}
+
+	for _, invalidLimit := range testCases {
+		t.Run("InvalidLimit_"+invalidLimit, func(t *testing.T) {
+			cmd := exec.Command("../maestro-k", "search", "test-db", "test query", "--doc-limit", invalidLimit)
+			output, err := cmd.CombinedOutput()
+
+			// The command should handle invalid limits gracefully
+			outputStr := string(output)
+
+			// It might fail due to argument parsing or MCP server, but shouldn't crash
+			if err == nil && !contains(outputStr, "[DRY RUN]") {
+				t.Error("Search command should handle invalid doc-limit gracefully")
+			}
+		})
+	}
+}
+
+// TestSearchCommandExists tests that the search command exists in the CLI
+func TestSearchCommandExists(t *testing.T) {
+	cmd := exec.Command("../maestro-k", "--help")
+	output, err := cmd.Output()
+
+	if err != nil {
+		t.Fatalf("Failed to run help command: %v", err)
+	}
+
+	helpOutput := string(output)
+	if !contains(helpOutput, "search") {
+		t.Error("Help output should contain 'search' command")
+	}
+}

--- a/src/db/vector_db_base.py
+++ b/src/db/vector_db_base.py
@@ -271,7 +271,9 @@ class VectorDatabase(ABC):
         pass
 
     @abstractmethod
-    def search(self, query: str, limit: int = 5, collection_name: str = None) -> list[dict]:
+    def search(
+        self, query: str, limit: int = 5, collection_name: str = None
+    ) -> list[dict]:
         """
         Search for documents using vector similarity search.
 

--- a/src/db/vector_db_base.py
+++ b/src/db/vector_db_base.py
@@ -263,9 +263,25 @@ class VectorDatabase(ABC):
         Args:
             query: The query string to search for
             limit: Maximum number of results to consider
+            collection_name: Optional collection name to search in
 
         Returns:
             A string response with relevant information from the database
+        """
+        pass
+
+    @abstractmethod
+    def search(self, query: str, limit: int = 5, collection_name: str = None) -> list[dict]:
+        """
+        Search for documents using vector similarity search.
+
+        Args:
+            query: The search query text
+            limit: Maximum number of results to return
+            collection_name: Optional collection name to search in
+
+        Returns:
+            List of documents sorted by relevance
         """
         pass
 

--- a/src/db/vector_db_milvus.py
+++ b/src/db/vector_db_milvus.py
@@ -637,13 +637,14 @@ class MilvusVectorDatabase(VectorDatabase):
         Args:
             query: The query string to search for
             limit: Maximum number of results to consider
+            collection_name: Optional collection name to search in (defaults to self.collection_name)
 
         Returns:
             A string response with relevant information from the database
         """
         try:
             # Perform vector similarity search
-            documents = self._search_documents(query, limit, collection_name)
+            documents = self.search(query, limit, collection_name)
 
             if not documents:
                 return f"No relevant documents found for query: '{query}'"
@@ -673,15 +674,16 @@ class MilvusVectorDatabase(VectorDatabase):
             warnings.warn(f"Failed to query Milvus: {e}")
             return f"Error querying database: {str(e)}"
 
-    def _search_documents(
+    def search(
         self, query: str, limit: int = 5, collection_name: str = None
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
-        Search for documents using vector similarity search.
+        Search for documents using Milvus vector similarity search.
 
         Args:
             query: The search query text
             limit: Maximum number of results to return
+            collection_name: Optional collection name to search in (defaults to self.collection_name)
 
         Returns:
             List of documents sorted by relevance
@@ -699,10 +701,9 @@ class MilvusVectorDatabase(VectorDatabase):
 
             # Perform vector similarity search
             results = self.client.search(
-                collection_name or self.collection_name,
+                collection_name=collection_name or self.collection_name,
                 data=[query_vector],
                 anns_field="vector",
-                param={"metric_type": "COSINE", "params": {"nprobe": 10}},
                 limit=limit,
                 output_fields=["id", "url", "text", "metadata"],
             )

--- a/src/maestro_mcp/server.py
+++ b/src/maestro_mcp/server.py
@@ -6,9 +6,10 @@ import json
 import logging
 import sys
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Coroutine
 
 from fastmcp import FastMCP
+from fastmcp.tools.tool import ToolResult
 from pydantic import BaseModel, Field
 
 from ..db.vector_db_factory import create_vector_database
@@ -197,6 +198,14 @@ class CreateCollectionInput(BaseModel):
 
 
 class QueryInput(BaseModel):
+    db_name: str = Field(..., description="Name of the vector database instance")
+    query: str = Field(..., description="The query string to search for")
+    limit: int = Field(default=5, description="Maximum number of results to consider")
+    collection_name: str = Field(
+        default=None, description="Optional collection name to search in"
+    )
+
+class SearchInput(BaseModel):
     db_name: str = Field(..., description="Name of the vector database instance")
     query: str = Field(..., description="The query string to search for")
     limit: int = Field(default=5, description="Maximum number of results to consider")
@@ -594,6 +603,20 @@ def create_mcp_server() -> FastMCP:
             return response
         except Exception as e:
             error_msg = f"Failed to query vector database '{input.db_name}': {str(e)}"
+            logger.error(error_msg)
+            return f"Error: {error_msg}"
+
+    @app.tool()
+    async def search(input: SearchInput) -> ToolResult:
+        """Search a vector database using vector similarity search."""
+        try:
+            db = get_database_by_name(input.db_name)
+            response = db.search(
+                input.query, limit=input.limit, collection_name=input.collection_name
+            )
+            return response
+        except Exception as e:
+            error_msg = f"Failed to search vector database '{input.db_name}': {str(e)}"
             logger.error(error_msg)
             return f"Error: {error_msg}"
 

--- a/src/maestro_mcp/server.py
+++ b/src/maestro_mcp/server.py
@@ -6,7 +6,7 @@ import json
 import logging
 import sys
 import os
-from typing import Any, Dict, List, Coroutine
+from typing import Any, Dict, List
 
 from fastmcp import FastMCP
 from fastmcp.tools.tool import ToolResult
@@ -204,6 +204,7 @@ class QueryInput(BaseModel):
     collection_name: str = Field(
         default=None, description="Optional collection name to search in"
     )
+
 
 class SearchInput(BaseModel):
     db_name: str = Field(..., description="Name of the vector database instance")

--- a/tests/test_query_functionality.py
+++ b/tests/test_query_functionality.py
@@ -138,11 +138,23 @@ class ConcreteQueryVectorDatabase(VectorDatabase):
     def create_query_agent(self):
         return self.query_agent
 
-    def query(self, query: str, limit: int = 5) -> str:
+    def query(self, query: str, limit: int = 5, collection_name: str = None) -> str:
         """Test implementation of query method."""
         try:
             # Mock the query agent response
             self.query_agent.run.return_value = f"Response to: {query}"
+            response = self.query_agent.run(query)
+            return response
+        except Exception as e:
+            return f"Error querying database: {str(e)}"
+
+    def search(
+        self, query: str, limit: int = 5, collection_name: str = None
+    ) -> list[dict]:
+        """Test implementation of search method."""
+        try:
+            # Mock the query agent response
+            self.query_agent.run.return_value = [{"result": f"Response to: {query}"}]
             response = self.query_agent.run(query)
             return response
         except Exception as e:

--- a/tests/test_vector_db_base.py
+++ b/tests/test_vector_db_base.py
@@ -124,8 +124,13 @@ class ConcreteVectorDatabase(VectorDatabase):
     def cleanup(self):
         self.documents = []
 
-    def query(self, query: str, limit: int = 5) -> str:
+    def query(self, query: str, limit: int = 5, collection_name: str = None) -> str:
         return f"Dummy query response: {query} (limit={limit})"
+
+    def search(
+        self, query: str, limit: int = 5, collection_name: str = None
+    ) -> list[dict]:
+        return [{"result": f"Dummy search response: {query} (limit={limit})"}]
 
 
 class TestConcreteVectorDatabase:


### PR DESCRIPTION
The `query` API returns a human readable summary of its search results. This is not very usable when you want to retrieve the documents that you're querying. This adds a `search` API that behaves the same as `query` but returns a list of the documents matched.

> DISCUSSION: I choose to leave `query` as is and add `search`, but I could have just changed the return value of `query`. If this is the preferred solution I can make that change.

Implementation details:
- The updates to add `search` in the go code is almost entirely duplicated from the `query` code, with added marshaling for the json object return (list[dict] instead of a string)
- Fixed a bug in the `query` go code where it wasn't actually passing the correct collection in (it was always using the default test collection)
- I added a new abstract method  `search` to `vector_db_base.py`, this function was already implemented in `vector_db_weaviate.py` and the private function `_search_documents ` in `vector_db_milvus.py` was renamed.
- Added `search` tool to mcp server