### PR TITLE
bug: fix issue with some write calls not returning response when error occurs

### DIFF
--- a/src/db/vector_db_milvus.py
+++ b/src/db/vector_db_milvus.py
@@ -466,7 +466,11 @@ class MilvusVectorDatabase(VectorDatabase):
         insert_duration_ms = 0
         if data:
             insert_start = time.perf_counter()
-            self.client.insert(target_collection, data)
+            try:
+                self.client.insert(target_collection, data)
+            except Exception as e:
+                # Re-raise the exception to be handled by the caller
+                raise e
             insert_duration_ms = int((time.perf_counter() - insert_start) * 1000)
 
             # Best-effort: ensure Milvus has flushed/loaded the inserted data so
@@ -1009,7 +1013,11 @@ class MilvusVectorDatabase(VectorDatabase):
             raise ValueError("Milvus document IDs must be convertible to integers.")
 
         # Delete documents by ID
-        self.client.delete(self.collection_name, ids=int_ids)
+        try:
+            self.client.delete(self.collection_name, ids=int_ids)
+        except Exception as e:
+            # Re-raise the exception to be handled by the caller
+            raise e
 
     def delete_collection(self, collection_name: str = None):
         """Delete an entire collection from Milvus."""

--- a/src/db/vector_db_weaviate.py
+++ b/src/db/vector_db_weaviate.py
@@ -248,58 +248,82 @@ class WeaviateVectorDatabase(VectorDatabase):
         total_chunks = 0
         build_start = time.perf_counter()
 
-        with collection.batch.dynamic() as batch:
-            for idx, doc in enumerate(documents):
-                doc_start = time.perf_counter()
-                orig_metadata = dict(doc.get("metadata", {}))
-                text = doc.get("text", "")
+        try:
+            with collection.batch.dynamic() as batch:
+                for idx, doc in enumerate(documents):
+                    doc_start = time.perf_counter()
+                    orig_metadata = dict(doc.get("metadata", {}))
+                    text = doc.get("text", "")
 
-                cfg = ChunkingConfig(
-                    strategy=(chunking_conf or {}).get("strategy", "None"),
-                    parameters=(chunking_conf or {}).get("parameters", {}),
-                )
-                chunks = chunk_text(text, cfg)
+                    cfg = ChunkingConfig(
+                        strategy=(chunking_conf or {}).get("strategy", "None"),
+                        parameters=(chunking_conf or {}).get("parameters", {}),
+                    )
+                    chunks = chunk_text(text, cfg)
 
-                per_doc_chunk_count = 0
-                per_doc_char_count = 0
+                    per_doc_chunk_count = 0
+                    per_doc_char_count = 0
 
-                for chunk in chunks:
-                    new_meta = dict(orig_metadata)
-                    if "doc_name" in orig_metadata:
-                        new_meta["doc_name"] = orig_metadata.get("doc_name")
-                    # omit chunking policy to reduce per-result duplication
-                    new_meta.update(
+                    for chunk in chunks:
+                        new_meta = dict(orig_metadata)
+                        if "doc_name" in orig_metadata:
+                            new_meta["doc_name"] = orig_metadata.get("doc_name")
+                        # omit chunking policy to reduce per-result duplication
+                        new_meta.update(
+                            {
+                                "chunk_sequence_number": int(chunk["sequence"]),
+                                "total_chunks": int(chunk["total"]),
+                                "offset_start": int(chunk["offset_start"]),
+                                "offset_end": int(chunk["offset_end"]),
+                                "chunk_size": int(chunk["chunk_size"]),
+                            }
+                        )
+                        per_doc_chunk_count += 1
+                        per_doc_char_count += len(chunk.get("text", "") or "")
+
+                        metadata_text = json.dumps(new_meta, ensure_ascii=False)
+                        batch.add_object(
+                            properties={
+                                "url": doc.get("url", ""),
+                                "text": chunk["text"],
+                                "metadata": metadata_text,
+                            }
+                        )
+
+                    total_chunks += per_doc_chunk_count
+                    stats_per_doc.append(
                         {
-                            "chunk_sequence_number": int(chunk["sequence"]),
-                            "total_chunks": int(chunk["total"]),
-                            "offset_start": int(chunk["offset_start"]),
-                            "offset_end": int(chunk["offset_end"]),
-                            "chunk_size": int(chunk["chunk_size"]),
+                            "name": orig_metadata.get("doc_name")
+                            or doc.get("url")
+                            or f"doc_{idx}",
+                            "chunk_count": per_doc_chunk_count,
+                            "char_count": per_doc_char_count,
+                            "duration_ms": int(
+                                (time.perf_counter() - doc_start) * 1000
+                            ),
                         }
                     )
-                    per_doc_chunk_count += 1
-                    per_doc_char_count += len(chunk.get("text", "") or "")
-
-                    metadata_text = json.dumps(new_meta, ensure_ascii=False)
-                    batch.add_object(
-                        properties={
-                            "url": doc.get("url", ""),
-                            "text": chunk["text"],
-                            "metadata": metadata_text,
-                        }
+            # Check for errors after the batch operation
+            if batch.failed_objects:
+                error_messages = []
+                for failed_obj in batch.failed_objects:
+                    error_messages.append(
+                        f"Failed to import object: {failed_obj.object_} - Error: {failed_obj.message}"
                     )
-
-                total_chunks += per_doc_chunk_count
-                stats_per_doc.append(
-                    {
-                        "name": orig_metadata.get("doc_name")
-                        or doc.get("url")
-                        or f"doc_{idx}",
-                        "chunk_count": per_doc_chunk_count,
-                        "char_count": per_doc_char_count,
-                        "duration_ms": int((time.perf_counter() - doc_start) * 1000),
-                    }
+                raise RuntimeError(
+                    f"Weaviate batch import failed for some objects: {'; '.join(error_messages)}"
                 )
+            if batch.failed_references:
+                error_messages = []
+                for failed_ref in batch.failed_references:
+                    error_messages.append(
+                        f"Failed to import reference: {failed_ref.reference_} - Error: {failed_ref.message}"
+                    )
+                raise RuntimeError(
+                    f"Weaviate batch import failed for some references: {'; '.join(error_messages)}"
+                )
+        except Exception as e:
+            raise RuntimeError(f"Error during Weaviate batch import: {e}") from e
 
         total_duration_ms = int((time.perf_counter() - build_start) * 1000)
 

--- a/tests/test_vector_db_weaviate.py
+++ b/tests/test_vector_db_weaviate.py
@@ -271,6 +271,8 @@ class TestWeaviateVectorDatabase:
             mock_client.collections.get.return_value = mock_collection
             mock_collection.batch.dynamic.return_value = mock_batch_context
             mock_batch_context.__enter__.return_value = mock_batch
+            mock_batch.failed_objects = []  # Add this line
+            mock_batch.failed_references = []  # Add this line
             mock_connect.return_value = mock_client
 
             db = WeaviateVectorDatabase()
@@ -317,6 +319,8 @@ class TestWeaviateVectorDatabase:
             mock_client.collections.get.return_value = mock_collection
             mock_collection.batch.dynamic.return_value = mock_batch_context
             mock_batch_context.__enter__.return_value = mock_batch
+            mock_batch.failed_objects = []  # Add this line
+            mock_batch.failed_references = []  # Add this line
             mock_connect.return_value = mock_client
 
             # Mock the configuration objects
@@ -364,6 +368,8 @@ class TestWeaviateVectorDatabase:
             mock_client.collections.get.return_value = mock_collection
             mock_collection.batch.dynamic.return_value = mock_batch_context
             mock_batch_context.__enter__.return_value = mock_batch
+            mock_batch.failed_objects = []  # Add this line
+            mock_batch.failed_references = []  # Add this line
             mock_connect.return_value = mock_client
 
             db = WeaviateVectorDatabase()


### PR DESCRIPTION
When errors occur (including being caused by other bugs - but also if a backend issue occurs), they are not being propogated back to the clients. (See one example in #51). This is particularly important on writes, where we say it occur in our cloud application. A document_write completed in around 14 minutes, but never returned to the client (though it did have it's own timeout which eventually expired at one hour)

This fix doesn't review all exception handling or look at modifying exception content, but it should ensure we catch the relevant cases so that the write call will get responded to.

Fixes #16


