### PR TITLE
test: ignore warn during error test

### DIFF
--- a/tests/test_vector_db_milvus.py
+++ b/tests/test_vector_db_milvus.py
@@ -589,6 +589,7 @@ class TestMilvusVectorDatabase:
             db.get_document("test_doc", "test_collection")
 
     @patch("pymilvus.MilvusClient")
+    @pytest.mark.filterwarnings("ignore:Failed to connect to Milvus")
     def test_get_document_no_client(self, mock_milvus_client: MagicMock) -> None:
         """Test getting a document when client is not available."""
         mock_milvus_client.side_effect = Exception("Connection failed")


### PR DESCRIPTION
On main, pytest is currently throwing two warnings:

```console
tests/test_mcp_query.py::TestMCPQueryFunctionality::test_query_tool_exists
  /Users/ajbozarth/workspace/quantum/ai/maestro-knowledge/.venv/lib/python3.12/site-packages/milvus_lite/__init__.py:15: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    from pkg_resources import DistributionNotFound, get_distribution

tests/test_vector_db_milvus.py::TestMilvusVectorDatabase::test_get_document_no_client
  /Users/ajbozarth/workspace/quantum/ai/maestro-knowledge/src/db/vector_db_milvus.py:99: UserWarning: Failed to connect to Milvus at milvus_demo.db or file://milvus_demo.db. Milvus operations will be disabled. Error: Connection failed
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

The first is caused upstream and has already been fixed in https://github.com/milvus-io/milvus-lite/commit/d0ffebfa43fc681b93db86a03a7688ec67f93fb6 but not yet release.

This fixes the second, where an error is thrown during a test for an error. I have added an `filterwarnings` decorator to ignore it, as it is expected when testing the error it warns could occur.