### PR TITLE
chore: reduce size of docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,97 @@
+# Python cache and virtual environments
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+venv/
+env/
+ENV/
+
+# UV and pip cache directories
+cache/
+.cache/
+.uv/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Test directories and files
+tests/
+test/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# Documentation
+docs/
+*.md
+README*
+CHANGELOG*
+LICENSE*
+CONTRIBUTING*
+
+# Git and version control
+.git/
+.gitignore
+.gitattributes
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Log files
+*.log
+logs/
+mcp_server*.log*
+
+# Database files (local testing)
+*.db
+*.sqlite
+*.sqlite3
+milvus_demo.db*
+test-milvus-data/
+volumes/
+
+# Temporary files
+tmp/
+temp/
+.tmp/
+
+# Configuration files (keep only what's needed)
+.env
+.env.*
+!.env.example
+
+# CLI binaries (built locally)
+maestro-k
+
+# Lock files that get regenerated
+*.lock
+!uv.lock
+
+# Testing and development artifacts
+.ruff_cache/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Examples and tools (not needed at runtime)
+examples/
+tools/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,16 @@ WORKDIR /app
 ENV PYTHONPATH=/app
 ENV UV_CACHE_DIR=/app/cache
 
-COPY ./src /app/src
-COPY pyproject.toml /app
-COPY start.sh /app
-COPY stop.sh /app
+COPY --chown=1000:1000 ./src /app/src
+COPY --chown=1000:1000 pyproject.toml /app
+COPY --chown=1000:1000 start.sh /app
+COPY --chown=1000:1000 stop.sh /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends procps
 
 RUN uv sync
 
-RUN chmod +x ./start.sh
-
-RUN chown -R 1000:1000 /app &&\
+RUN chmod +x ./start.sh && \
   mkdir -p /app/cache && chown 1000:1000 /app/cache
 
 EXPOSE 8030

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,36 @@
+# Start with the slim base image
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-WORKDIR /app
 
+# Set working directory and environment variables
+WORKDIR /app
 ENV PYTHONPATH=/app
 ENV UV_CACHE_DIR=/app/cache
 
-COPY --chown=1000:1000 ./src /app/src
-COPY --chown=1000:1000 pyproject.toml /app
-COPY --chown=1000:1000 start.sh /app
-COPY --chown=1000:1000 stop.sh /app
+# 1. Install system packages and create the non-root user and app directory.
+# This layer changes infrequently.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends procps && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd --create-home --shell /bin/bash appuser --uid 1000 && \
+    chown -R 1000:1000 /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends procps
+# Switch to the non-root user
+USER appuser
 
+# 2. Copy only the dependency definition file.
+COPY --chown=1000:1000 pyproject.toml .
+
+# 3. Install Python dependencies.
+# This layer will now only be rebuilt if 'pyproject.toml' changes,
+# not every time you change a source file.
 RUN uv sync
 
-RUN chmod +x ./start.sh && \
-  mkdir -p /app/cache && chown 1000:1000 /app/cache
+# 4. Copy the rest of the application code.
+# This is the most frequently changed part, so it comes last.
+COPY --chown=1000:1000 ./src /app/src
+COPY --chown=1000:1000 start.sh stop.sh /app/
+RUN chmod +x /app/start.sh
 
+# Define the port and the final command to run the application
 EXPOSE 8030
-USER 1000:1000
-
 ENTRYPOINT ["uv", "run", "./start.sh", "--host", "0.0.0.0", "--tail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR /app
 ENV PYTHONPATH=/app
 ENV UV_CACHE_DIR=/app/cache
 
-# 1. Install system packages and create the non-root user and app directory.
-# This layer changes infrequently.
+# Install system packages and create the non-root user and app directory.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends procps && \
     rm -rf /var/lib/apt/lists/* && \
@@ -17,20 +16,17 @@ RUN apt-get update && \
 # Switch to the non-root user
 USER appuser
 
-# 2. Copy only the dependency definition file.
+# Copy the dependency definition file.
 COPY --chown=1000:1000 pyproject.toml .
 
-# 3. Install Python dependencies.
-# This layer will now only be rebuilt if 'pyproject.toml' changes,
-# not every time you change a source file.
+# Install Python dependencies.
 RUN uv sync
 
-# 4. Copy the rest of the application code.
-# This is the most frequently changed part, so it comes last.
+# Copy the the maestro knowledge code.
 COPY --chown=1000:1000 ./src /app/src
 COPY --chown=1000:1000 start.sh stop.sh /app/
 RUN chmod +x /app/start.sh
 
-# Define the port and the final command to run the application
+# Launch the server
 EXPOSE 8030
 ENTRYPOINT ["uv", "run", "./start.sh", "--host", "0.0.0.0", "--tail"]


### PR DESCRIPTION
Reduces size of docker image (primarily intel)

Eliminates unnecessary cache files from image (could be extensive on intel)

Partially addresses #67

Tested on apple silicon mac:
```
docker buildx build --platform linux/amd64 -f ./Dockerfile . --load -t maestro-knowledge:smalldock2
KIND_EXPERIMENTAL_PROVIDER=podman kind load docker-image maestro-knowledge:smalldock2
helm install qiskit-studio-local charts/qiskit-studio -f charts/qiskit-studio/values-local.yaml  --set icrKey="${ICR_KEY}" --set knowledgeMcp.image.repository='docker.io/library/maestro-knowledge' \
  --set knowledgeMcp.image.tag='smalldock2'
```
And the doc loader runs ie:

```
==================================================
📊 DOCUMENT PROCESSING SUMMARY
==================================================
Total documents processed: 7
Documents added:           7
Documents skipped:         0 (already existed)
Documents failed:          0
Total chunks added:        430
Total processing time:     231.42 seconds
==================================================

DETAILED DOCUMENT RESULTS:
--------------------------------------------------
URL                            | Status     | Chunks | Time (s) | Error
--------------------------------------------------
./documentation/quantum-...    | added      | 21     | 22.98    | None
./documentation/qunova-h...    | added      | 69     | 36.09    | None
./documentation/chsh-ine...    | added      | 36     | 18.56    | None
./documentation/combine-...    | added      | 38     | 19.28    | None
./documentation/improvin...    | added      | 53     | 26.56    | None
./documentation/improvin...    | added      | 118    | 60.44    | None
./documentation/quantum-...    | added      | 95     | 47.50    | None
--------------------------------------------------

✅ Total script execution time: 247.41 seconds
```

The mcp server does take a long time to become ready (I tweaked timeouts)
- This may be exacerbated by the fact it's running emulation
- original image has same issue

Image now 7.5GB
```
maestro-knowledge                  smalldock         4d325ecea084   18 minutes ago   7.48GB
```

The arm image is also now smaller
```
maestro-knowledge                  smalldock2-arm    3fd7be683eb8   54 seconds ago   1.24GB
```

